### PR TITLE
Fixed erroneous @Override

### DIFF
--- a/src/main/java/org/terasology/multiBlock2/block/InvisibleInMultiBlockStructureSidedBlockFamily.java
+++ b/src/main/java/org/terasology/multiBlock2/block/InvisibleInMultiBlockStructureSidedBlockFamily.java
@@ -106,7 +106,6 @@ public class InvisibleInMultiBlockStructureSidedBlockFamily extends AbstractBloc
         return blockMap.values();
     }
 
-    @Override
     public Side getSide(Block block) {
         for (Map.Entry<Side, Block> sideBlockEntry : visibleBlocks.entrySet()) {
             if (block == sideBlockEntry.getValue()) {


### PR DESCRIPTION
No ancestor classes or interfaces seem to have a getSize() method.  All uses of this method seem to be local as well.  Fixes error:

:modules:MultiBlock:compileJava/.../MultiBlock/src/main/java/org/terasology/multiBlock2/block/InvisibleInMultiBlockStructureSidedBlockFamily.java:109: error: method does not override or implement a method from a supertype
