### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/multiBlock2/component/MultiBlockCandidateComponent.java
+++ b/src/main/java/org/terasology/multiBlock2/component/MultiBlockCandidateComponent.java
@@ -8,7 +8,7 @@ import java.util.Collections;
 import java.util.Set;
 
 public class MultiBlockCandidateComponent implements Component<MultiBlockCandidateComponent> {
-    private Set<String> type;
+    public Set<String> type;
 
     public Set<String> getType() {
         return Collections.unmodifiableSet(type);

--- a/src/main/java/org/terasology/multiBlock2/component/MultiBlockComponent.java
+++ b/src/main/java/org/terasology/multiBlock2/component/MultiBlockComponent.java
@@ -9,8 +9,8 @@ import org.terasology.gestalt.entitysystem.component.Component;
  * Not for external use!
  */
 public class MultiBlockComponent implements Component<MultiBlockComponent> {
-    private String type;
-    private EntityRef mainBlockEntity;
+    public String type;
+    public EntityRef mainBlockEntity;
 
     public MultiBlockComponent() {
     }

--- a/src/main/java/org/terasology/multiBlock2/component/MultiBlockMainComponent.java
+++ b/src/main/java/org/terasology/multiBlock2/component/MultiBlockMainComponent.java
@@ -19,10 +19,10 @@ import java.util.stream.Collectors;
  */
 @ForceBlockActive
 public class MultiBlockMainComponent implements Component<MultiBlockMainComponent> {
-    private List<Vector3i> multiBlockMembers;
-    private BlockRegion aabb;
-    private EntityRef multiBlockEntity;
-    private String multiBlockType;
+    public List<Vector3i> multiBlockMembers;
+    public BlockRegion aabb;
+    public EntityRef multiBlockEntity;
+    public String multiBlockType;
 
     public MultiBlockMainComponent() {
     }

--- a/src/main/java/org/terasology/multiBlock2/component/MultiBlockMemberComponent.java
+++ b/src/main/java/org/terasology/multiBlock2/component/MultiBlockMemberComponent.java
@@ -11,7 +11,7 @@ import org.terasology.gestalt.entitysystem.component.Component;
  */
 @ForceBlockActive
 public class MultiBlockMemberComponent implements Component<MultiBlockMemberComponent> {
-    private Vector3i mainBlockLocation;
+    public Vector3i mainBlockLocation;
 
     public MultiBlockMemberComponent() {
     }


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191